### PR TITLE
interestingly, underscores break stack :|

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This uses `hi` to provide the bootstrapping
 
 0. stack install --resolver=lts-7.18 hi
   - if it fails `git clone git@github.com:trofi/hi && cd hi && stack install && cd ..`
-1. hi my-project --repository gh:tippenein/slab
-2. cd my-project
+1. hi myProject --repository gh:tippenein/slab
+2. cd myProject
 3. make db_user
 4. make
 


### PR DESCRIPTION
I guess this can be cataloged under "wasting time on dumb software problems, but as documented [here](https://github.com/commercialhaskell/stack/issues/696), you get weird parse failures on cabal files when stack project names have underscores in them. :|